### PR TITLE
Add rack-cors gem to Gemfile

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -33,7 +33,7 @@ gem "thruster", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.1)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -295,6 +298,7 @@ DEPENDENCIES
   debug
   kamal
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.2, >= 8.0.2.1)
   rubocop-rails-omakase
   solid_cable


### PR DESCRIPTION
## 概要
rails apiモードでフロントエンドをVue.jsにしているため、異なるオリジン間での通信が必要となります。
それを有効にするためにgemを追加しました。

## 変更点
gem "rack-cors"を追加しました

## 関連Issue

## 動作確認


## その他
