### PR TITLE
createアクションの削除

### DIFF
--- a/backend/app/controllers/users/sessions_controller.rb
+++ b/backend/app/controllers/users/sessions_controller.rb
@@ -1,13 +1,8 @@
 class Users::SessionsController < Devise::SessionsController
-  before_action :configure_sign_in_params, only: [:create]
+
   respond_to :json
-
-  def create
-    super
-  end
-
+  
   private
-
   def respond_with(resource, _opts={})
     render json: {
       message: "Welcome, you're in",
@@ -36,11 +31,5 @@ class Users::SessionsController < Devise::SessionsController
 
   def failed_logout
     render json: { message: "Something went wrong." }, status: :unauthorized
-  end
-
-  def configure_sign_in_params
-    devise_parameter_sanitizer.permit(:sign_in) do |user_params|
-      user_params.permit(:email, :password)
-    end
   end
 end


### PR DESCRIPTION
## 概要
sessionsコントローラーにcreateメソッドと、strong parametersを実装しておりましたが、ある記事を参考にしたメソッドがそのまま使えたため、上2つは削除しました。
参考にしたサイトはdevise-jwt公式ドキュメントではないですが、devise-jwtを用いたAPI認証の仕様を書いた、企業による記事です。
[引用サイト(英語原文)](https://blog.appsignal.com/2023/08/02/advanced-usages-of-devise-for-rails.html)
[日本語訳サイト](https://techracho.bpsinc.jp/hachi8833/2023_09_04/133454)

## 動作確認
問題なくステータスコード200を返していました。